### PR TITLE
Change cap3 skeleton Gemfile to use rbenv from github.

### DIFF
--- a/skeletons/cap3/Gemfile
+++ b/skeletons/cap3/Gemfile
@@ -5,7 +5,7 @@ gem "capistrano", ">=3.0.0"
 gem "capistrano-multiconfig", ">=3.0.3"
 
 # gem "capistrano-bundler",  ">=1.0.0"
-# gem "capistrano-rbenv",    ">=1.0.5"
+# gem "capistrano-rbenv", github: "capistrano/rbenv"
 # gem "capistrano-rails",    ">=1.0.0"
 # gem "capistrano-uptodate", ">=0.0.2"
 # gem "capistrano-patch",    ">=0.0.2"


### PR DESCRIPTION
capistrano-rbenv on rubygems is actually another gem for managing rubies: http://rubygems.org/gems/capistrano-rbenv

from here: https://github.com/yyuu/capistrano-rbenv

so I think you actually meant to use this one: https://github.com/capistrano/rbenv
